### PR TITLE
.Fix reworked approach to check health state

### DIFF
--- a/client.go
+++ b/client.go
@@ -405,3 +405,8 @@ func (c *client) workerSaveExit(name string, errs chan<- error) {
 		errs <- err
 	}
 }
+
+// Ping send a ping over the socket to the peer
+func (c *client) Ping() error {
+	return c.conn.Ping()
+}

--- a/cosmos.go
+++ b/cosmos.go
@@ -137,8 +137,5 @@ func (c *Cosmos) String() string {
 
 // IsHealthy returns nil if the Cosmos DB connection is alive, otherwise an error is returned
 func (c *Cosmos) IsHealthy() error {
-	if !c.IsConnected() {
-		return fmt.Errorf("Not connected")
-	}
-	return nil
+	return c.pool.Ping()
 }

--- a/cosmos_test.go
+++ b/cosmos_test.go
@@ -1,6 +1,7 @@
 package gremcos
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -64,11 +65,11 @@ func TestIsHealthy(t *testing.T) {
 	cosmos.pool = mockedQueryExecutor
 
 	// WHEN -- connected --> healthy
-	mockedQueryExecutor.EXPECT().IsConnected().Return(true)
+	mockedQueryExecutor.EXPECT().Ping().Return(nil)
 	healthyWhenConnected := cosmos.IsHealthy()
 
 	// WHEN -- not connected --> not healthy
-	mockedQueryExecutor.EXPECT().IsConnected().Return(false)
+	mockedQueryExecutor.EXPECT().Ping().Return(fmt.Errorf("Not connected"))
 	healthyWhenNotConnected := cosmos.IsHealthy()
 
 	// THEN

--- a/interfaces/queryExecutor.go
+++ b/interfaces/queryExecutor.go
@@ -14,6 +14,7 @@ type QueryExecutor interface {
 	ExecuteFileWithBindings(path string, bindings, rebindings map[string]string) (resp []Response, err error)
 	ExecuteFile(path string) (resp []Response, err error)
 	ExecuteWithBindings(query string, bindings, rebindings map[string]string) (resp []Response, err error)
+	Ping() error
 }
 
 const (

--- a/pool.go
+++ b/pool.go
@@ -334,3 +334,16 @@ func (pc *pooledConnection) Close() {
 	pc.pool.put(pc)
 	pc.pool.release()
 }
+
+// Ping obtains/ creates a connection from the pool and
+// sends the ping control message over the underlying websocket.
+func (p *pool) Ping() error {
+	pc, err := p.Get()
+	if err != nil {
+		return err
+	}
+
+	// put the connection back into the idle pool
+	defer pc.Close()
+	return pc.client.Ping()
+}

--- a/test/mocks/interfaces/mock_queryExecutor.go
+++ b/test/mocks/interfaces/mock_queryExecutor.go
@@ -148,3 +148,17 @@ func (mr *MockQueryExecutorMockRecorder) ExecuteWithBindings(query, bindings, re
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExecuteWithBindings", reflect.TypeOf((*MockQueryExecutor)(nil).ExecuteWithBindings), query, bindings, rebindings)
 }
+
+// Ping mocks base method
+func (m *MockQueryExecutor) Ping() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Ping")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Ping indicates an expected call of Ping
+func (mr *MockQueryExecutorMockRecorder) Ping() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Ping", reflect.TypeOf((*MockQueryExecutor)(nil).Ping))
+}


### PR DESCRIPTION
Using the information if there was a successful connection is not a good idea since one needs to create at least one connection beforehand. It is the better approach to find out actively if a connection to the peer is possible or not. 
Hence we now create a websocket and then send a ping control message over this connection to the peer.