### PR TITLE
QueryBuilder extended

### DIFF
--- a/api/edge.go
+++ b/api/edge.go
@@ -72,3 +72,13 @@ func (e *edge) InV() interfaces.Vertex {
 func (e *edge) Profile() interfaces.QueryBuilder {
 	return e.Add(NewSimpleQB(".executionProfile()"))
 }
+
+// HasLabel adds .hasLabel('<label>'), e.g. .hasLabel('user'), to the query. The query call returns all edges with the given label.
+func (e *edge) HasLabel(label string) interfaces.Edge {
+	return e.Add(NewSimpleQB(".hasLabel('%s')", label))
+}
+
+// Count adds .count(), to the query. The query call will return the number of entities found in the query.
+func (e *edge) Count() interfaces.QueryBuilder {
+	return e.Add(NewSimpleQB(".count()"))
+}

--- a/api/edge_test.go
+++ b/api/edge_test.go
@@ -156,3 +156,38 @@ func TestOutV(t *testing.T) {
 	assert.NotNil(t, v)
 	assert.Equal(t, fmt.Sprintf("%s.outV()", graphName), e.String())
 }
+
+func TestEdgeHasLabel(t *testing.T) {
+
+	// GIVEN
+	graphName := "mygraph"
+	g := NewGraph(graphName)
+	require.NotNil(t, g)
+	e := NewEdgeG(g)
+	require.NotNil(t, e)
+	label := "label"
+
+	// WHEN
+	e = e.HasLabel(label)
+
+	// THEN
+	assert.NotNil(t, e)
+	assert.Equal(t, fmt.Sprintf("%s.hasLabel('%s')", graphName, label), e.String())
+}
+
+func TestEdgeCount(t *testing.T) {
+
+	// GIVEN
+	graphName := "mygraph"
+	g := NewGraph(graphName)
+	require.NotNil(t, g)
+	e := NewEdgeG(g)
+	require.NotNil(t, e)
+
+	// WHEN
+	qb := e.Count()
+
+	// THEN
+	assert.NotNil(t, qb)
+	assert.Equal(t, fmt.Sprintf("%s.count()", graphName), qb.String())
+}

--- a/api/vertex.go
+++ b/api/vertex.go
@@ -105,3 +105,20 @@ func (v *vertex) HasInt(key string, value int) interfaces.Vertex {
 func (v *vertex) PropertyInt(key string, value int) interfaces.Vertex {
 	return v.Add(NewSimpleQB(".property('%s',%d)", key, value))
 }
+
+// OutE adds .outE(), to the query. The query call returns all outgoing edges of the Vertex
+func (v *vertex) OutE() interfaces.Edge {
+	v.Add(NewSimpleQB(".outE()"))
+	return NewEdgeV(v)
+}
+
+// InE adds .inE(), to the query. The query call returns all incoming edges of the Vertex
+func (v *vertex) InE() interfaces.Edge {
+	v.Add(NewSimpleQB(".inE()"))
+	return NewEdgeV(v)
+}
+
+// Count adds .count(), to the query. The query call will return the number of entities found in the query.
+func (v *vertex) Count() interfaces.QueryBuilder {
+	return v.Add(NewSimpleQB(".count()"))
+}

--- a/api/vertex_test.go
+++ b/api/vertex_test.go
@@ -277,3 +277,54 @@ func TestChain(t *testing.T) {
 	assert.NotNil(t, qb)
 	assert.Equal(t, fmt.Sprintf("%s.addV('%s').property('%s','%s').property('%s','%s').properties()", graphName, vertrexlabel, key1, value1, key2, value2), qb.String())
 }
+
+func TestVertexCount(t *testing.T) {
+
+	// GIVEN
+	graphName := "mygraph"
+	g := NewGraph(graphName)
+	require.NotNil(t, g)
+	v := NewVertexG(g)
+	require.NotNil(t, v)
+
+	// WHEN
+	qb := v.Count()
+
+	// THEN
+	assert.NotNil(t, qb)
+	assert.Equal(t, fmt.Sprintf("%s.count()", graphName), qb.String())
+}
+
+func TestOutE(t *testing.T) {
+
+	// GIVEN
+	graphName := "mygraph"
+	g := NewGraph(graphName)
+	require.NotNil(t, g)
+	v := NewVertexG(g)
+	require.NotNil(t, v)
+
+	// WHEN
+	e := v.OutE()
+
+	// THEN
+	assert.NotNil(t, e)
+	assert.Equal(t, fmt.Sprintf("%s.outE()", graphName), e.String())
+}
+
+func TestInE(t *testing.T) {
+
+	// GIVEN
+	graphName := "mygraph"
+	g := NewGraph(graphName)
+	require.NotNil(t, g)
+	v := NewVertexG(g)
+	require.NotNil(t, v)
+
+	// WHEN
+	e := v.InE()
+
+	// THEN
+	assert.NotNil(t, e)
+	assert.Equal(t, fmt.Sprintf("%s.inE()", graphName), e.String())
+}

--- a/interfaces/queryBuilder.go
+++ b/interfaces/queryBuilder.go
@@ -30,6 +30,7 @@ type Vertex interface {
 	QueryBuilder
 	Dropper
 	Profiler
+	Counter
 
 	// HasLabel adds .hasLabel('<label>'), e.g. .hasLabel('user'), to the query. The query call returns all vertices with the given label.
 	HasLabel(vertexLabel string) Vertex
@@ -59,12 +60,19 @@ type Vertex interface {
 
 	// AddE adds .addE(<label>), to the query. The query call will be the first step to add an edge
 	AddE(label string) Edge
+
+	// OutE adds .outE(), to the query. The query call returns all outgoing edges of the Vertex
+	OutE() Edge
+
+	// InE adds .inE(), to the query. The query call returns all incoming edges of the Vertex
+	InE() Edge
 }
 
 type Edge interface {
 	QueryBuilder
 	Dropper
 	Profiler
+	Counter
 
 	// To adds .to(<vertex>), to the query. The query call will be the second step to add an edge
 	To(v Vertex) Edge
@@ -75,8 +83,12 @@ type Edge interface {
 	OutV() Vertex
 	// InV adds .inV(), to the query. The query call will return the vertices on the incoming side of this edge
 	InV() Vertex
-
+	// Add can be used to add a custom QueryBuilder
+	// e.g. g.V().Add(NewSimpleQB(".myCustomCall('%s')",label))
 	Add(builder QueryBuilder) Edge
+
+	// HasLabel adds .hasLabel('<label>'), e.g. .hasLabel('user'), to the query. The query call returns all edges with the given label.
+	HasLabel(label string) Edge
 }
 
 type Dropper interface {
@@ -85,6 +97,11 @@ type Dropper interface {
 }
 
 type Profiler interface {
-	// Profile adds ..executionProfile(), to the query. The query call will return profiling information of the executed query
+	// Profile adds .executionProfile(), to the query. The query call will return profiling information of the executed query
 	Profile() QueryBuilder
+}
+
+type Counter interface {
+	// Count adds .count(), to the query. The query call will return the number of entities found in the query.
+	Count() QueryBuilder
 }


### PR DESCRIPTION
With this PR the following methods are added to the query builder:
- count()
- edge.hasLabel()
- outE()
- inE()