### PR TITLE
.Fix support properties and labels that contains a '

### DIFF
--- a/api/edge.go
+++ b/api/edge.go
@@ -35,7 +35,7 @@ func (e *edge) String() string {
 }
 
 // Add can be used to add a custom QueryBuilder
-// e.g. g.V().Add(NewSimpleQB(".myCustomCall('%s')",label))
+// e.g. g.V().Add(NewSimpleQB(".myCustomCall("%s")",label))
 func (e *edge) Add(builder interfaces.QueryBuilder) interfaces.Edge {
 	e.builders = append(e.builders, builder)
 	return e
@@ -73,9 +73,9 @@ func (e *edge) Profile() interfaces.QueryBuilder {
 	return e.Add(NewSimpleQB(".executionProfile()"))
 }
 
-// HasLabel adds .hasLabel('<label>'), e.g. .hasLabel('user'), to the query. The query call returns all edges with the given label.
+// HasLabel adds .hasLabel("<label>"), e.g. .hasLabel("user"), to the query. The query call returns all edges with the given label.
 func (e *edge) HasLabel(label string) interfaces.Edge {
-	return e.Add(NewSimpleQB(".hasLabel('%s')", label))
+	return e.Add(NewSimpleQB(".hasLabel(\"%s\")", label))
 }
 
 // Count adds .count(), to the query. The query call will return the number of entities found in the query.

--- a/api/edge_test.go
+++ b/api/edge_test.go
@@ -172,7 +172,7 @@ func TestEdgeHasLabel(t *testing.T) {
 
 	// THEN
 	assert.NotNil(t, e)
-	assert.Equal(t, fmt.Sprintf("%s.hasLabel('%s')", graphName, label), e.String())
+	assert.Equal(t, fmt.Sprintf("%s.hasLabel(\"%s\")", graphName, label), e.String())
 }
 
 func TestEdgeCount(t *testing.T) {

--- a/api/graph.go
+++ b/api/graph.go
@@ -28,21 +28,21 @@ func (g *graph) V() interfaces.Vertex {
 // VBy adds .V(<id>), e.g. .V(123)
 func (g *graph) VBy(id int) interfaces.Vertex {
 	vertex := NewVertexG(g)
-	vertex.Add(NewSimpleQB(".V('%d')", id))
+	vertex.Add(NewSimpleQB(".V(\"%d\")", id))
 	return vertex
 }
 
-// VByUUID adds .V(<id>), e.g. .V('8fff9259-09e6-4ea5-aaf8-250b31cc7f44'), to the query. The query call returns the vertex with the given id.
+// VByUUID adds .V(<id>), e.g. .V("8fff9259-09e6-4ea5-aaf8-250b31cc7f44"), to the query. The query call returns the vertex with the given id.
 func (g *graph) VByUUID(id uuid.UUID) interfaces.Vertex {
 	vertex := NewVertexG(g)
-	vertex.Add(NewSimpleQB(".V('%s')", id))
+	vertex.Add(NewSimpleQB(".V(\"%s\")", id))
 	return vertex
 }
 
-// AddV adds .addV('<label>'), e.g. .addV('user')
+// AddV adds .addV("<label>"), e.g. .addV("user")
 func (g *graph) AddV(label string) interfaces.Vertex {
 	vertex := NewVertexG(g)
-	vertex.Add(NewSimpleQB(".addV('%s')", label))
+	vertex.Add(NewSimpleQB(".addV(\"%s\")", label))
 	return vertex
 }
 

--- a/api/graph_test.go
+++ b/api/graph_test.go
@@ -47,7 +47,7 @@ func TestVBy(t *testing.T) {
 
 	// THEN
 	assert.NotNil(t, v)
-	assert.Equal(t, fmt.Sprintf("%s.V('%d')", graphName, id), v.String())
+	assert.Equal(t, fmt.Sprintf("%s.V(\"%d\")", graphName, id), v.String())
 }
 
 func TestVByUUID(t *testing.T) {
@@ -63,7 +63,7 @@ func TestVByUUID(t *testing.T) {
 
 	// THEN
 	assert.NotNil(t, v)
-	assert.Equal(t, fmt.Sprintf("%s.V('%s')", graphName, id), v.String())
+	assert.Equal(t, fmt.Sprintf("%s.V(\"%s\")", graphName, id), v.String())
 }
 
 func TestAddV(t *testing.T) {
@@ -78,7 +78,7 @@ func TestAddV(t *testing.T) {
 
 	// THEN
 	assert.NotNil(t, v)
-	assert.Equal(t, fmt.Sprintf("%s.addV('%s')", graphName, label), v.String())
+	assert.Equal(t, fmt.Sprintf("%s.addV(\"%s\")", graphName, label), v.String())
 }
 
 func TestE(t *testing.T) {

--- a/api/vertex.go
+++ b/api/vertex.go
@@ -37,25 +37,25 @@ func NewVertexE(e interfaces.Edge) interfaces.Vertex {
 }
 
 // Add can be used to add a custom QueryBuilder
-// e.g. g.V().Add(NewSimpleQB(".myCustomCall('%s')",label))
+// e.g. g.V().Add(NewSimpleQB(".myCustomCall("%s")",label))
 func (v *vertex) Add(builder interfaces.QueryBuilder) interfaces.Vertex {
 	v.builders = append(v.builders, builder)
 	return v
 }
 
-// Has adds .has('<key>','<value>'), e.g. .has('name','hans')
+// Has adds .has("<key>","<value>"), e.g. .has("name","hans")
 func (v *vertex) Has(key, value string) interfaces.Vertex {
-	return v.Add(NewSimpleQB(".has('%s','%s')", key, value))
+	return v.Add(NewSimpleQB(".has(\"%s\",\"%s\")", key, value))
 }
 
-// HasLabel adds .hasLabel('<label>'), e.g. .hasLabel('user')
+// HasLabel adds .hasLabel("<label>"), e.g. .hasLabel("user")
 func (v *vertex) HasLabel(vertexLabel string) interfaces.Vertex {
-	return v.Add(NewSimpleQB(".hasLabel('%s')", vertexLabel))
+	return v.Add(NewSimpleQB(".hasLabel(\"%s\")", vertexLabel))
 }
 
-// ValuesBy adds .values('<label>'), e.g. .values('user')
+// ValuesBy adds .values("<label>"), e.g. .values("user")
 func (v *vertex) ValuesBy(label string) interfaces.QueryBuilder {
-	return v.Add(NewSimpleQB(".values('%s')", label))
+	return v.Add(NewSimpleQB(".values(\"%s\")", label))
 }
 
 // Values adds .values()
@@ -73,9 +73,9 @@ func (v *vertex) Properties() interfaces.QueryBuilder {
 	return v.Add(NewSimpleQB(".properties()"))
 }
 
-// Property adds .property('<key>','<value>'), e.g. .property('name','hans')
+// Property adds .property("<key>","<value>"), e.g. .property("name","hans")
 func (v *vertex) Property(key, value string) interfaces.Vertex {
-	return v.Add(NewSimpleQB(".property('%s','%s')", key, value))
+	return v.Add(NewSimpleQB(".property(\"%s\",\"%s\")", key, value))
 }
 
 // Id adds .id()
@@ -90,7 +90,7 @@ func (v *vertex) Drop() interfaces.QueryBuilder {
 
 // AddE adds .addE(<label>), to the query. The query call will be the first step to add an edge
 func (v *vertex) AddE(label string) interfaces.Edge {
-	v.Add(NewSimpleQB(".addE('%s')", label))
+	v.Add(NewSimpleQB(".addE(\"%s\")", label))
 	return NewEdgeV(v)
 }
 
@@ -99,11 +99,11 @@ func (v *vertex) Profile() interfaces.QueryBuilder {
 }
 
 func (v *vertex) HasInt(key string, value int) interfaces.Vertex {
-	return v.Add(NewSimpleQB(".has('%s',%d)", key, value))
+	return v.Add(NewSimpleQB(".has(\"%s\",%d)", key, value))
 }
 
 func (v *vertex) PropertyInt(key string, value int) interfaces.Vertex {
-	return v.Add(NewSimpleQB(".property('%s',%d)", key, value))
+	return v.Add(NewSimpleQB(".property(\"%s\",%d)", key, value))
 }
 
 // OutE adds .outE(), to the query. The query call returns all outgoing edges of the Vertex
@@ -123,7 +123,7 @@ func (v *vertex) Count() interfaces.QueryBuilder {
 	return v.Add(NewSimpleQB(".count()"))
 }
 
-// PropertyList adds .property(list,'<key>','<value>'), e.g. .property(list, 'name','hans'), to the query. The query call will add the given property.
+// PropertyList adds .property(list,"<key>","<value>"), e.g. .property(list, "name","hans"), to the query. The query call will add the given property.
 func (v *vertex) PropertyList(key, value string) interfaces.Vertex {
-	return v.Add(NewSimpleQB(".property(list,'%s','%s')", key, value))
+	return v.Add(NewSimpleQB(".property(list,\"%s\",\"%s\")", key, value))
 }

--- a/api/vertex_test.go
+++ b/api/vertex_test.go
@@ -53,7 +53,7 @@ func TestHas(t *testing.T) {
 
 	// THEN
 	assert.NotNil(t, v)
-	assert.Equal(t, fmt.Sprintf("%s.V().has('%s','%s')", graphName, key, value), v.String())
+	assert.Equal(t, fmt.Sprintf("%s.V().has(\"%s\",\"%s\")", graphName, key, value), v.String())
 }
 
 func TestHasInt(t *testing.T) {
@@ -71,7 +71,7 @@ func TestHasInt(t *testing.T) {
 
 	// THEN
 	assert.NotNil(t, v)
-	assert.Equal(t, fmt.Sprintf("%s.V().has('%s',%d)", graphName, key, value), v.String())
+	assert.Equal(t, fmt.Sprintf("%s.V().has(\"%s\",%d)", graphName, key, value), v.String())
 }
 
 func TestPropertyInt(t *testing.T) {
@@ -89,7 +89,7 @@ func TestPropertyInt(t *testing.T) {
 
 	// THEN
 	assert.NotNil(t, v)
-	assert.Equal(t, fmt.Sprintf("%s.V().property('%s',%d)", graphName, key, value), v.String())
+	assert.Equal(t, fmt.Sprintf("%s.V().property(\"%s\",%d)", graphName, key, value), v.String())
 }
 
 func TestHasLabel(t *testing.T) {
@@ -106,7 +106,7 @@ func TestHasLabel(t *testing.T) {
 
 	// THEN
 	assert.NotNil(t, v)
-	assert.Equal(t, fmt.Sprintf("%s.V().hasLabel('%s')", graphName, label), v.String())
+	assert.Equal(t, fmt.Sprintf("%s.V().hasLabel(\"%s\")", graphName, label), v.String())
 }
 
 func TestValuesBy(t *testing.T) {
@@ -123,7 +123,7 @@ func TestValuesBy(t *testing.T) {
 
 	// THEN
 	assert.NotNil(t, qb)
-	assert.Equal(t, fmt.Sprintf("%s.V().values('%s')", graphName, label), qb.String())
+	assert.Equal(t, fmt.Sprintf("%s.V().values(\"%s\")", graphName, label), qb.String())
 }
 
 func TestValues(t *testing.T) {
@@ -189,7 +189,7 @@ func TestProperty(t *testing.T) {
 
 	// THEN
 	assert.NotNil(t, v)
-	assert.Equal(t, fmt.Sprintf("%s.V().property('%s','%s')", graphName, key, value), v.String())
+	assert.Equal(t, fmt.Sprintf("%s.V().property(\"%s\",\"%s\")", graphName, key, value), v.String())
 }
 
 func TestId(t *testing.T) {
@@ -254,7 +254,7 @@ func TestAddE(t *testing.T) {
 
 	// THEN
 	assert.NotNil(t, qb)
-	assert.Equal(t, fmt.Sprintf("%s.V().addE('%s')", graphName, label), qb.String())
+	assert.Equal(t, fmt.Sprintf("%s.V().addE(\"%s\")", graphName, label), qb.String())
 }
 
 func TestChain(t *testing.T) {
@@ -275,7 +275,7 @@ func TestChain(t *testing.T) {
 
 	// THEN
 	assert.NotNil(t, qb)
-	assert.Equal(t, fmt.Sprintf("%s.addV('%s').property('%s','%s').property('%s','%s').properties()", graphName, vertrexlabel, key1, value1, key2, value2), qb.String())
+	assert.Equal(t, fmt.Sprintf("%s.addV(\"%s\").property(\"%s\",\"%s\").property(\"%s\",\"%s\").properties()", graphName, vertrexlabel, key1, value1, key2, value2), qb.String())
 }
 
 func TestVertexCount(t *testing.T) {
@@ -345,5 +345,5 @@ func TestPropertyList(t *testing.T) {
 
 	// THEN
 	assert.NotNil(t, v)
-	assert.Equal(t, fmt.Sprintf("%s.property(list,'%s','%s')", graphName, key, value), v.String())
+	assert.Equal(t, fmt.Sprintf("%s.property(list,\"%s\",\"%s\")", graphName, key, value), v.String())
 }


### PR DESCRIPTION
# Problem
If one want's to store a property or label that contains a ' like `RUE DE L'INDUSTRIE`

The query fails with 
`Gremlin Query Syntax Error: Script compile error: Missing ')' @ line 1, column 275.`

Since the query strings are built using single instead of double quotes, each single quote inside the property string breaks the string and thus makes the query invalid.

# Solution
Use double quotes.