### PR TITLE
Avoid that for the event of a close of a channel an error log is written

### DIFF
--- a/pool.go
+++ b/pool.go
@@ -201,8 +201,8 @@ func (p *pool) purge() {
 		if err := idleConnection.pc.client.LastError(); err != nil {
 
 			// only log the error in case it is not the socket closed event
-			if err != socketClosedEvent {
-				p.logger.Info().Err(err).Msg("Remove connection from pool due to an error")
+			if err.Error() != socketClosedEvent.Error() {
+				p.logger.Info().Err(err).Msgf("Remove connection from pool due to an error [%s]", err.Error())
 			}
 
 			// Force underlying connection closed


### PR DESCRIPTION
In case the websocket is closed there is usually a frame with type '-1' received.
Atm this is treated as an error and logged each time this situation occurs.

To avoid spamming those messages into the log, we now filter for this particular situation and log all errors but this.