### PR TITLE
F/45 Support for multi label queries

### DIFF
--- a/api/edge.go
+++ b/api/edge.go
@@ -73,9 +73,10 @@ func (e *edge) Profile() interfaces.QueryBuilder {
 	return e.Add(NewSimpleQB(".executionProfile()"))
 }
 
-// HasLabel adds .hasLabel("<label>"), e.g. .hasLabel("user"), to the query. The query call returns all edges with the given label.
-func (e *edge) HasLabel(label string) interfaces.Edge {
-	return e.Add(NewSimpleQB(".hasLabel(\"%s\")", label))
+// HasLabel adds .hasLabel([<label_1>,<label_2>,..,<label_n>]), e.g. .hasLabel('user','name'), to the query. The query call returns all edges with the given label.
+func (e *edge) HasLabel(labels ...string) interfaces.Edge {
+	query := multiParamQuery(".hasLabel", labels...)
+	return e.Add(query)
 }
 
 // Count adds .count(), to the query. The query call will return the number of entities found in the query.

--- a/api/edge_test.go
+++ b/api/edge_test.go
@@ -175,6 +175,25 @@ func TestEdgeHasLabel(t *testing.T) {
 	assert.Equal(t, fmt.Sprintf("%s.hasLabel(\"%s\")", graphName, label), e.String())
 }
 
+func TestEdgeHasLabelMulti(t *testing.T) {
+
+	// GIVEN
+	graphName := "mygraph"
+	g := NewGraph(graphName)
+	require.NotNil(t, g)
+	e := NewEdgeG(g)
+	require.NotNil(t, e)
+	l1 := "label1"
+	l2 := "label2"
+
+	// WHEN
+	e = e.HasLabel(l1, l2)
+
+	// THEN
+	assert.NotNil(t, e)
+	assert.Equal(t, fmt.Sprintf("%s.hasLabel(\"%s\",\"%s\")", graphName, l1, l2), e.String())
+}
+
 func TestEdgeCount(t *testing.T) {
 
 	// GIVEN

--- a/api/graph.go
+++ b/api/graph.go
@@ -1,6 +1,9 @@
 package api
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/gofrs/uuid"
 	"github.com/supplyon/gremcos/interfaces"
 )
@@ -62,4 +65,24 @@ func (g *graph) E() interfaces.Edge {
 
 func (g *graph) String() string {
 	return g.name
+}
+
+// multiParamQuery creates a query based on the given (optional) parameters.
+// The query is the name of the query method that supports 0..* parameters.
+// Examples:
+//    q1:=multiParamQuery(".out","label1","label2") ==> generates ".out('label1','label2')"
+//    q2:=multiParamQuery(".out") ==> generates ".out()"
+func multiParamQuery(query string, params ...string) interfaces.QueryBuilder {
+	if len(params) == 0 {
+		return NewSimpleQB(fmt.Sprintf("%s()", query))
+	}
+
+	qStr := ""
+	for _, p := range params {
+		qStr += fmt.Sprintf("\"%s\",", p)
+	}
+
+	qStr = strings.TrimSuffix(qStr, ",")
+	qStr = fmt.Sprintf("%s(%s)", query, qStr)
+	return NewSimpleQB(qStr)
 }

--- a/api/graph.go
+++ b/api/graph.go
@@ -77,12 +77,7 @@ func multiParamQuery(query string, params ...string) interfaces.QueryBuilder {
 		return NewSimpleQB(fmt.Sprintf("%s()", query))
 	}
 
-	qStr := ""
-	for _, p := range params {
-		qStr += fmt.Sprintf("\"%s\",", p)
-	}
-
-	qStr = strings.TrimSuffix(qStr, ",")
-	qStr = fmt.Sprintf("%s(%s)", query, qStr)
+	qStr := strings.Join(params, "\",\"")
+	qStr = fmt.Sprintf("%s(\"%s\")", query, qStr)
 	return NewSimpleQB(qStr)
 }

--- a/api/graph_test.go
+++ b/api/graph_test.go
@@ -109,3 +109,22 @@ func TestE(t *testing.T) {
 	assert.NotNil(t, v)
 	assert.Equal(t, fmt.Sprintf("%s.E()", graphName), v.String())
 }
+
+func TestMultiparamQuery(t *testing.T) {
+
+	// GIVEN
+	queryStr := ".outE"
+	l1 := "label1"
+	l2 := "label2"
+
+	// WHEN
+	q1 := multiParamQuery(queryStr)
+	q2 := multiParamQuery(queryStr, l1)
+	q3 := multiParamQuery(queryStr, l1, l2)
+
+	// THEN
+	assert.NotNil(t, q1)
+	assert.Equal(t, ".outE()", q1.String())
+	assert.Equal(t, ".outE(\"label1\")", q2.String())
+	assert.Equal(t, ".outE(\"label1\",\"label2\")", q3.String())
+}

--- a/api/vertex.go
+++ b/api/vertex.go
@@ -48,9 +48,10 @@ func (v *vertex) Has(key, value string) interfaces.Vertex {
 	return v.Add(NewSimpleQB(".has(\"%s\",\"%s\")", key, Escape(value)))
 }
 
-// HasLabel adds .hasLabel("<label>"), e.g. .hasLabel("user")
-func (v *vertex) HasLabel(vertexLabel string) interfaces.Vertex {
-	return v.Add(NewSimpleQB(".hasLabel(\"%s\")", vertexLabel))
+// HasLabel adds .hasLabel([<label_1>,<label_2>,..,<label_n>]), e.g. .hasLabel('user','name'), to the query. The query call returns all vertices with the given label.
+func (v *vertex) HasLabel(vertexLabel ...string) interfaces.Vertex {
+	query := multiParamQuery(".hasLabel", vertexLabel...)
+	return v.Add(query)
 }
 
 // ValuesBy adds .values("<label>"), e.g. .values("user")
@@ -106,15 +107,17 @@ func (v *vertex) PropertyInt(key string, value int) interfaces.Vertex {
 	return v.Add(NewSimpleQB(".property(\"%s\",%d)", key, value))
 }
 
-// OutE adds .outE(), to the query. The query call returns all outgoing edges of the Vertex
-func (v *vertex) OutE() interfaces.Edge {
-	v.Add(NewSimpleQB(".outE()"))
+// OutE adds .outE([<label_1>,<label_2>,..,<label_n>]), to the query. The query call returns all outgoing edges of the Vertex
+func (v *vertex) OutE(labels ...string) interfaces.Edge {
+	query := multiParamQuery(".outE", labels...)
+	v.Add(query)
 	return NewEdgeV(v)
 }
 
-// InE adds .inE(), to the query. The query call returns all incoming edges of the Vertex
-func (v *vertex) InE() interfaces.Edge {
-	v.Add(NewSimpleQB(".inE()"))
+// InE adds .inE([<label_1>,<label_2>,..,<label_n>]), to the query. The query call returns all incoming edges of the Vertex
+func (v *vertex) InE(labels ...string) interfaces.Edge {
+	query := multiParamQuery(".inE", labels...)
+	v.Add(query)
 	return NewEdgeV(v)
 }
 

--- a/api/vertex_test.go
+++ b/api/vertex_test.go
@@ -109,6 +109,24 @@ func TestHasLabel(t *testing.T) {
 	assert.Equal(t, fmt.Sprintf("%s.V().hasLabel(\"%s\")", graphName, label), v.String())
 }
 
+func TestHasLabelMulti(t *testing.T) {
+	// GIVEN
+	graphName := "mygraph"
+	g := NewGraph(graphName)
+	require.NotNil(t, g)
+	v := g.V()
+	require.NotNil(t, v)
+	l1 := "label1"
+	l2 := "label2"
+
+	// WHEN
+	v = v.HasLabel(l1, l2)
+
+	// THEN
+	assert.NotNil(t, v)
+	assert.Equal(t, fmt.Sprintf("%s.V().hasLabel(\"%s\",\"%s\")", graphName, l1, l2), v.String())
+}
+
 func TestValuesBy(t *testing.T) {
 	// GIVEN
 	graphName := "mygraph"
@@ -312,6 +330,25 @@ func TestOutE(t *testing.T) {
 	assert.Equal(t, fmt.Sprintf("%s.outE()", graphName), e.String())
 }
 
+func TestOutEMulti(t *testing.T) {
+
+	// GIVEN
+	graphName := "mygraph"
+	g := NewGraph(graphName)
+	require.NotNil(t, g)
+	v := NewVertexG(g)
+	require.NotNil(t, v)
+	l1 := "label1"
+	l2 := "label2"
+
+	// WHEN
+	e := v.OutE(l1, l2)
+
+	// THEN
+	assert.NotNil(t, e)
+	assert.Equal(t, fmt.Sprintf("%s.outE(\"label1\",\"label2\")", graphName), e.String())
+}
+
 func TestInE(t *testing.T) {
 
 	// GIVEN
@@ -327,6 +364,25 @@ func TestInE(t *testing.T) {
 	// THEN
 	assert.NotNil(t, e)
 	assert.Equal(t, fmt.Sprintf("%s.inE()", graphName), e.String())
+}
+
+func TestInEMulti(t *testing.T) {
+
+	// GIVEN
+	graphName := "mygraph"
+	g := NewGraph(graphName)
+	require.NotNil(t, g)
+	v := NewVertexG(g)
+	require.NotNil(t, v)
+	l1 := "label1"
+	l2 := "label2"
+
+	// WHEN
+	e := v.InE(l1, l2)
+
+	// THEN
+	assert.NotNil(t, e)
+	assert.Equal(t, fmt.Sprintf("%s.inE(\"label1\",\"label2\")", graphName), e.String())
 }
 
 func TestPropertyList(t *testing.T) {

--- a/interfaces/queryBuilder.go
+++ b/interfaces/queryBuilder.go
@@ -34,8 +34,8 @@ type Vertex interface {
 	Profiler
 	Counter
 
-	// HasLabel adds .hasLabel('<label>'), e.g. .hasLabel('user'), to the query. The query call returns all vertices with the given label.
-	HasLabel(vertexLabel string) Vertex
+	// HasLabel adds .hasLabel([<label_1>,<label_2>,..,<label_n>]), e.g. .hasLabel('user','name'), to the query. The query call returns all vertices with the given label.
+	HasLabel(vertexLabel ...string) Vertex
 	// Property adds .property('<key>','<value>'), e.g. .property('name','hans'), to the query. The query call will add the given property.
 	Property(key, value string) Vertex
 	// PropertyInt adds .property('<key>',<int value>), e.g. .property('age',55), to the query. The query call will add the given property.
@@ -65,11 +65,11 @@ type Vertex interface {
 	// AddE adds .addE(<label>), to the query. The query call will be the first step to add an edge
 	AddE(label string) Edge
 
-	// OutE adds .outE(), to the query. The query call returns all outgoing edges of the Vertex
-	OutE() Edge
+	// OutE adds .outE([<label_1>,<label_2>,..,<label_n>]), to the query. The query call returns all outgoing edges of the Vertex
+	OutE(labels ...string) Edge
 
-	// InE adds .inE(), to the query. The query call returns all incoming edges of the Vertex
-	InE() Edge
+	// InE adds .inE([<label_1>,<label_2>,..,<label_n>]), to the query. The query call returns all incoming edges of the Vertex
+	InE(labels ...string) Edge
 }
 
 type Edge interface {
@@ -91,8 +91,8 @@ type Edge interface {
 	// e.g. g.V().Add(NewSimpleQB(".myCustomCall('%s')",label))
 	Add(builder QueryBuilder) Edge
 
-	// HasLabel adds .hasLabel('<label>'), e.g. .hasLabel('user'), to the query. The query call returns all edges with the given label.
-	HasLabel(label string) Edge
+	// HasLabel adds .hasLabel([<label_1>,<label_2>,..,<label_n>]), e.g. .hasLabel('user','name'), to the query. The query call returns all edges with the given label.
+	HasLabel(label ...string) Edge
 }
 
 type Dropper interface {


### PR DESCRIPTION
Adds multi label parameters to queries Vertex.OutE(), Vertex.InE(), Vertex.HasLabel() and Edge.HasLabel().

As a result one can call:
* `v.OutE("user","admin")`
* `v.OutE()`
* `v.HasLabel("blue","fast")`