### PR TITLE
Enhance support for local gremlin-server

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ build: sep ## Builds the library
 
 test: sep ## Runs all unittests and generates a coverage report.
 	@echo "--> Run the unit-tests and checks for race conditions."
-	@go test . ./api -timeout 30s -race -run "^Test.*[^IT]$$" -covermode=atomic
+	@go test . ./api ./interfaces -timeout 30s -race -run "^Test.*[^IT]$$" -covermode=atomic
 
 
 test.integration: sep ## Runs all integration tests. As precondition a local gremlin-server has to run and listen on port 8182.
@@ -31,7 +31,7 @@ lint: ## Runs the linter to check for coding-style issues
 
 report.test: sep ## Runs all unittests and generates a coverage- and a test-report.
 	@echo "--> Run the unit-tests"	
-	@go test . ./api -timeout 30s -race -run "^Test.*[^IT]$$" -covermode=atomic -coverprofile=coverage.out -json | tee test-report.out
+	@go test . ./api ./interfaces -timeout 30s -race -run "^Test.*[^IT]$$" -covermode=atomic -coverprofile=coverage.out -json | tee test-report.out
 
 report.lint: ## Runs the linter to check for coding-style issues and generates the report file used in the ci pipeline
 	@echo "--> Lint project + Reporting"

--- a/api/responseMapper.go
+++ b/api/responseMapper.go
@@ -10,6 +10,9 @@ type ResponseArray []interfaces.Response
 func (responses ResponseArray) ToValues() ([]TypedValue, error) {
 	result := make([]TypedValue, 0)
 	for _, response := range responses {
+		if response.IsEmpty() {
+			continue
+		}
 		values, err := ToValues(response.Result.Data)
 		if err != nil {
 			return nil, err
@@ -24,6 +27,9 @@ func (responses ResponseArray) ToValues() ([]TypedValue, error) {
 func (responses ResponseArray) ToProperties() ([]Property, error) {
 	result := make([]Property, 0)
 	for _, response := range responses {
+		if response.IsEmpty() {
+			continue
+		}
 		properties, err := ToProperties(response.Result.Data)
 		if err != nil {
 			return nil, err
@@ -38,6 +44,9 @@ func (responses ResponseArray) ToProperties() ([]Property, error) {
 func (responses ResponseArray) ToVertices() ([]Vertex, error) {
 	result := make([]Vertex, 0)
 	for _, response := range responses {
+		if response.IsEmpty() {
+			continue
+		}
 		vertices, err := ToVertices(response.Result.Data)
 		if err != nil {
 			return nil, err
@@ -52,6 +61,9 @@ func (responses ResponseArray) ToVertices() ([]Vertex, error) {
 func (responses ResponseArray) ToEdges() ([]Edge, error) {
 	result := make([]Edge, 0)
 	for _, response := range responses {
+		if response.IsEmpty() {
+			continue
+		}
 		edges, err := ToEdges(response.Result.Data)
 		if err != nil {
 			return nil, err

--- a/api/responseMapper_test.go
+++ b/api/responseMapper_test.go
@@ -173,17 +173,3 @@ func TestResponseToEdges_Null(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Empty(t, values)
 }
-
-func TestResponseToEdges_Empty(t *testing.T) {
-	t.Parallel()
-	// GIVEN
-	data := ""
-	responses := createTestResponse(data)
-
-	// WHEN
-	values, err := responses.ToEdges()
-
-	// THEN
-	assert.NoError(t, err)
-	assert.Empty(t, values)
-}

--- a/api/responseMapper_test.go
+++ b/api/responseMapper_test.go
@@ -35,6 +35,20 @@ func TestResponseToValues(t *testing.T) {
 	assert.True(t, values[2].AsBool())
 }
 
+func TestResponseToValues_Null(t *testing.T) {
+	t.Parallel()
+	// GIVEN
+	data := "null"
+	responses := createTestResponse(data)
+
+	// WHEN
+	values, err := responses.ToValues()
+
+	// THEN
+	assert.NoError(t, err)
+	assert.Empty(t, values)
+}
+
 func TestResponseToProperties(t *testing.T) {
 	t.Parallel()
 	// GIVEN
@@ -54,6 +68,20 @@ func TestResponseToProperties(t *testing.T) {
 	assert.Equal(t, "8fff9259-09e6-4ea5-aaf8-250b31cc7f44|pk", properties[0].ID)
 	assert.Equal(t, "prop value", properties[0].Value.AsString())
 	assert.Equal(t, "prop key", properties[0].Label)
+}
+
+func TestResponseToProperties_Null(t *testing.T) {
+	t.Parallel()
+	// GIVEN
+	data := "null"
+	responses := createTestResponse(data)
+
+	// WHEN
+	values, err := responses.ToProperties()
+
+	// THEN
+	assert.NoError(t, err)
+	assert.Empty(t, values)
 }
 
 func TestResponseToVertices(t *testing.T) {
@@ -90,6 +118,20 @@ func TestResponseToVertices(t *testing.T) {
 	assert.Len(t, vertices[0].Properties, 3)
 }
 
+func TestResponseToVertices_Null(t *testing.T) {
+	t.Parallel()
+	// GIVEN
+	data := "null"
+	responses := createTestResponse(data)
+
+	// WHEN
+	values, err := responses.ToVertices()
+
+	// THEN
+	assert.NoError(t, err)
+	assert.Empty(t, values)
+}
+
 func TestResponseToEdges(t *testing.T) {
 	t.Parallel()
 	// GIVEN
@@ -116,4 +158,32 @@ func TestResponseToEdges(t *testing.T) {
 	assert.Equal(t, "user2", edges[0].OutVLabel)
 	assert.Equal(t, "7404ba4e-be30-486e-88e1-b2f5937a9001", edges[0].InV)
 	assert.Equal(t, "1111ba4e-be30-486e-88e1-b2f5937a9001", edges[0].OutV)
+}
+
+func TestResponseToEdges_Null(t *testing.T) {
+	t.Parallel()
+	// GIVEN
+	data := "null"
+	responses := createTestResponse(data)
+
+	// WHEN
+	values, err := responses.ToEdges()
+
+	// THEN
+	assert.NoError(t, err)
+	assert.Empty(t, values)
+}
+
+func TestResponseToEdges_Empty(t *testing.T) {
+	t.Parallel()
+	// GIVEN
+	data := ""
+	responses := createTestResponse(data)
+
+	// WHEN
+	values, err := responses.ToEdges()
+
+	// THEN
+	assert.NoError(t, err)
+	assert.Empty(t, values)
 }

--- a/gremcos_util_test.go
+++ b/gremcos_util_test.go
@@ -45,10 +45,10 @@ func newTestPool(t *testing.T, errChan chan error) *pool {
 func truncateData(t *testing.T, client interfaces.QueryExecutor) {
 	t.Log("Removing all data from gremlin server started...")
 
-	_, err := client.Execute(`g.V('1234').drop()`)
+	_, err := client.Execute(`g.V().has("user_id","1234").drop()`)
 	require.NoError(t, err)
 
-	_, err = client.Execute(`g.V('2145').drop()`)
+	_, err = client.Execute(`g.V().has("user_id","2145").drop()`)
 	require.NoError(t, err)
 	t.Log("Removing all data from gremlin server completed...")
 }
@@ -59,17 +59,17 @@ func seedData(t *testing.T, client interfaces.QueryExecutor) {
 	t.Log("Seeding data started...")
 
 	_, err := client.Execute(`
-		g.addV('Phil').property(id, '1234').
-			property('timestamp', '2018-07-01T13:37:45-05:00').
-			property('source', 'tree').
-			as('x').
-		  addV('Vincent').property(id, '2145').
-			property('timestamp', '2018-07-01T13:37:45-05:00').
-			property('source', 'tree').
-			as('y').
-		  addE('brother').
-			from('x').
-			to('y')
+		g.addV("Phil").property("user_id", "1234").
+			property("timestamp", "2018-07-01T13:37:45-05:00").
+			property("source", "tree").
+			as("x").
+		  addV("Vincent").property("user_id", "2145").
+			property("timestamp", "2018-07-01T13:37:45-05:00").
+			property("source", "tree").
+			as("y").
+		  addE("brother").
+			from("x").
+			to("y")
 	`)
 	require.NoError(t, err)
 	t.Log("Seeding data completed...")

--- a/infra/Dockerfile
+++ b/infra/Dockerfile
@@ -1,6 +1,7 @@
 FROM tinkerpop/gremlin-server:3.4.0
 
 COPY gremlin-server.yaml /opt/gremlin-server/conf/gremlin-server.yaml
+COPY tinkergraph-empty.properties conf/tinkergraph-empty.properties
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["conf/gremlin-server.yaml"]

--- a/infra/tinkergraph-empty.properties
+++ b/infra/tinkergraph-empty.properties
@@ -1,0 +1,10 @@
+gremlin.graph=org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerGraph
+
+# use UUID as default IdManager
+gremlin.tinkergraph.edgeIdManager=UUID
+gremlin.tinkergraph.vertexIdManager=UUID
+gremlin.tinkergraph.vertexPropertyIdManager=UUID
+
+# storage
+gremlin.tinkergraph.graphLocation=volume/graph.json
+gremlin.tinkergraph.graphFormat=graphson

--- a/interfaces/queryExecutor.go
+++ b/interfaces/queryExecutor.go
@@ -62,3 +62,19 @@ type AsyncResponse struct {
 func (r Response) String() string {
 	return fmt.Sprintf("Response \nRequestID: %v, \nStatus: {%#v}, \nResult: {%#v}\n", r.RequestID, r.Status, r.Result)
 }
+
+// IsEmpty returns true if the given Response contains no data (e.g. due to a query that results in a empty result set).
+func (r Response) IsEmpty() bool {
+	if r.Result.Data == nil {
+		return true
+	}
+	if len(r.Result.Data) == 0 {
+		return true
+	}
+	// Handling of gremlin-server returning "null" in case of
+	// a query returned no result instead of '[]' (as it is done by cosmos).
+	if string(r.Result.Data) == "null" {
+		return true
+	}
+	return false
+}

--- a/interfaces/queryExecutor_test.go
+++ b/interfaces/queryExecutor_test.go
@@ -1,0 +1,28 @@
+package interfaces
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsEmpty(t *testing.T) {
+	t.Parallel()
+	// GIVEN
+	response1 := Response{}
+	response2 := Response{Result: Result{Data: []byte("")}}
+	response3 := Response{Result: Result{Data: []byte("null")}}
+	response4 := Response{Result: Result{Data: []byte("some data")}}
+
+	// WHEN
+	res1 := response1.IsEmpty()
+	res2 := response2.IsEmpty()
+	res3 := response3.IsEmpty()
+	res4 := response4.IsEmpty()
+
+	// THEN
+	assert.True(t, res1)
+	assert.True(t, res2)
+	assert.True(t, res3)
+	assert.False(t, res4)
+}

--- a/scripts/test-wbindings.groovy
+++ b/scripts/test-wbindings.groovy
@@ -1,1 +1,1 @@
-g.V(x).label();
+g.V().has('user_id',x).label();

--- a/scripts/test.groovy
+++ b/scripts/test.groovy
@@ -1,1 +1,1 @@
-g.V('2145').label();
+g.V().has('user_id','2145').label();


### PR DESCRIPTION
With this PR the local gremlin-server uses uuid's as database ids in order to be compatible to the behavior of CosmosDB.
Furthermore a workaround, for handling the behavior of gremlin-server returning "null" as response data in case a query results into a empty result set, was added.