### PR TITLE
[#56] .Update ensure that props are returned

### DIFF
--- a/infra/Dockerfile
+++ b/infra/Dockerfile
@@ -2,6 +2,7 @@ FROM tinkerpop/gremlin-server:3.4.0
 
 COPY gremlin-server.yaml /opt/gremlin-server/conf/gremlin-server.yaml
 COPY tinkergraph-empty.properties conf/tinkergraph-empty.properties
+COPY initialize_graph.groovy scripts/initialize_graph.groovy
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["conf/gremlin-server.yaml"]

--- a/infra/gremlin-server.yaml
+++ b/infra/gremlin-server.yaml
@@ -26,7 +26,7 @@ scriptEngines: {
     plugins: { org.apache.tinkerpop.gremlin.server.jsr223.GremlinServerGremlinPlugin: {},
                org.apache.tinkerpop.gremlin.tinkergraph.jsr223.TinkerGraphGremlinPlugin: {},
                org.apache.tinkerpop.gremlin.jsr223.ImportGremlinPlugin: {classImports: [java.lang.Math], methodImports: [java.lang.Math#*]},
-               org.apache.tinkerpop.gremlin.jsr223.ScriptFileGremlinPlugin: {files: [scripts/empty-sample.groovy]}}}}
+               org.apache.tinkerpop.gremlin.jsr223.ScriptFileGremlinPlugin: {files: [scripts/initialize_graph.groovy]}}}}
 serializers:
   - { className: org.apache.tinkerpop.gremlin.driver.ser.GryoMessageSerializerV3d0, config: { ioRegistries: [org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerIoRegistryV3d0] }}             # application/vnd.gremlin-v3.0+gryo
   - { className: org.apache.tinkerpop.gremlin.driver.ser.GryoMessageSerializerV3d0, config: { serializeResultToString: true }}                                                                       # application/vnd.gremlin-v3.0+gryo-stringd

--- a/infra/initialize_graph.groovy
+++ b/infra/initialize_graph.groovy
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// An example of an initialization script that can be configured to run in Gremlin Server.
+// Functions defined here will go into global cache and will not be removed from there
+// unless there is a reset of the ScriptEngine.
+def addItUp(x, y) { x + y }
+
+// an init script that returns a Map allows explicit setting of global bindings.
+def globals = [:]
+
+// defines a sample LifeCycleHook that prints some output to the Gremlin Server console.
+// note that the name of the key in the "global" map is unimportant.
+globals << [hook : [
+  onStartUp: { ctx ->
+    ctx.logger.info("Starting initialize_graph.groovy. Executed once at startup of Gremlin Server.")
+  },
+  onShutDown: { ctx ->
+    ctx.logger.info("Executed once at shutdown of Gremlin Server.")
+  }
+] as LifeCycleHook]
+
+// Don't use ReferenceElementStrategy in order to ensure to be compatible with the cosmos DB implementation.
+// CosmosDB returns vertices and edges always WITH their properties. 
+// If the ReferenceElementStrategy would be used the vertices and edges would be returned WITHOUT their properties.
+// See: https://stackoverflow.com/questions/55388014/gremlin-tinkerpop-propertymap-has-values-but-vertex-properties-is-empty
+// See: https://tinkerpop.apache.org/docs/current/reference/#_properties_of_elements
+globals << [g : graph.traversal()]


### PR DESCRIPTION
Don't use ReferenceElementStrategy in order to ensure to be compatible with the cosmos DB implementation.
CosmosDB returns vertices and edges always WITH their properties. 
If the ReferenceElementStrategy would be used the vertices and edges would be returned WITHOUT their properties.
See: 
* https://stackoverflow.com/questions/55388014/gremlin-tinkerpop-propertymap-has-values-but-vertex-properties-is-empty
* https://tinkerpop.apache.org/docs/current/reference/#_properties_of_elements