### PR TITLE
Adds the as() step to the query API

### DIFF
--- a/api/edge.go
+++ b/api/edge.go
@@ -41,6 +41,12 @@ func (e *edge) Add(builder interfaces.QueryBuilder) interfaces.Edge {
 	return e
 }
 
+// As adds .as([<label_1>,<label_2>,..,<label_n>]), to the query to label that query step for later access.
+func (e *edge) As(labels ...string) interfaces.Edge {
+	query := multiParamQuery(".as", labels...)
+	return e.Add(query)
+}
+
 // Limit adds .limit(<num>), to the query. The query call will limit the results of the query to the given number.
 func (e *edge) Limit(maxElements int) interfaces.Edge {
 	return e.Add(NewSimpleQB(".limit(%d)", maxElements))

--- a/api/edge_test.go
+++ b/api/edge_test.go
@@ -280,3 +280,40 @@ func TestEdgeLimit(t *testing.T) {
 	assert.NotNil(t, edge)
 	assert.Equal(t, fmt.Sprintf(`%s.limit(%d)`, graphName, limit), e.String())
 }
+
+func TestEdgeAs(t *testing.T) {
+
+	// GIVEN
+	graphName := "mygraph"
+	g := NewGraph(graphName)
+	require.NotNil(t, g)
+	e := NewEdgeG(g)
+	require.NotNil(t, e)
+	label := "label"
+
+	// WHEN
+	e = e.As(label)
+
+	// THEN
+	assert.NotNil(t, e)
+	assert.Equal(t, fmt.Sprintf("%s.as(\"%s\")", graphName, label), e.String())
+}
+
+func TestEdgeAsMulti(t *testing.T) {
+
+	// GIVEN
+	graphName := "mygraph"
+	g := NewGraph(graphName)
+	require.NotNil(t, g)
+	e := NewEdgeG(g)
+	require.NotNil(t, e)
+	l1 := "label1"
+	l2 := "label2"
+
+	// WHEN
+	e = e.As(l1, l2)
+
+	// THEN
+	assert.NotNil(t, e)
+	assert.Equal(t, fmt.Sprintf("%s.as(\"%s\",\"%s\")", graphName, l1, l2), e.String())
+}

--- a/api/property.go
+++ b/api/property.go
@@ -54,3 +54,9 @@ func (p *property) Count() interfaces.QueryBuilder {
 func (p *property) Limit(maxElements int) interfaces.Property {
 	return p.Add(NewSimpleQB(".limit(%d)", maxElements))
 }
+
+// As adds .as([<label_1>,<label_2>,..,<label_n>]), to the query to label that query step for later access.
+func (p *property) As(labels ...string) interfaces.Property {
+	query := multiParamQuery(".as", labels...)
+	return p.Add(query)
+}

--- a/api/property_test.go
+++ b/api/property_test.go
@@ -141,3 +141,44 @@ func TestPropertyLimit(t *testing.T) {
 	assert.NotNil(t, edge)
 	assert.Equal(t, fmt.Sprintf(`%s.limit(%d)`, graphName, limit), p.String())
 }
+
+func TestPropertyAs(t *testing.T) {
+
+	// GIVEN
+	graphName := "mygraph"
+	g := NewGraph(graphName)
+	require.NotNil(t, g)
+	v := NewVertexG(g)
+	require.NotNil(t, v)
+	p := NewPropertyV(v)
+	require.NotNil(t, p)
+	label := "label1"
+
+	// WHEN
+	p = p.As(label)
+
+	// THEN
+	assert.NotNil(t, p)
+	assert.Equal(t, fmt.Sprintf("%s.as(\"%s\")", graphName, label), p.String())
+}
+
+func TestPropertyAsMulti(t *testing.T) {
+
+	// GIVEN
+	graphName := "mygraph"
+	g := NewGraph(graphName)
+	require.NotNil(t, g)
+	v := NewVertexG(g)
+	require.NotNil(t, v)
+	p := NewPropertyV(v)
+	require.NotNil(t, p)
+	l1 := "label1"
+	l2 := "label2"
+
+	// WHEN
+	p = p.As(l1, l2)
+
+	// THEN
+	assert.NotNil(t, p)
+	assert.Equal(t, fmt.Sprintf("%s.as(\"%s\",\"%s\")", graphName, l1, l2), p.String())
+}

--- a/api/vertex.go
+++ b/api/vertex.go
@@ -47,6 +47,12 @@ func (v *vertex) Limit(maxElements int) interfaces.Vertex {
 	return v.Add(NewSimpleQB(".limit(%d)", maxElements))
 }
 
+// As adds .as([<label_1>,<label_2>,..,<label_n>]), to the query to label that query step for later access.
+func (v *vertex) As(labels ...string) interfaces.Vertex {
+	query := multiParamQuery(".as", labels...)
+	return v.Add(query)
+}
+
 // Add can be used to add a custom QueryBuilder
 // e.g. g.V().Add(NewSimpleQB(".myCustomCall("%s")",label))
 func (v *vertex) Add(builder interfaces.QueryBuilder) interfaces.Vertex {

--- a/api/vertex_test.go
+++ b/api/vertex_test.go
@@ -680,3 +680,40 @@ func TestVertexLimit(t *testing.T) {
 	assert.NotNil(t, edge)
 	assert.Equal(t, fmt.Sprintf(`%s.V().limit(%d)`, graphName, limit), v.String())
 }
+
+func TestVertexAs(t *testing.T) {
+
+	// GIVEN
+	graphName := "mygraph"
+	g := NewGraph(graphName)
+	require.NotNil(t, g)
+	v := g.V()
+	require.NotNil(t, v)
+	label := "label1"
+
+	// WHEN
+	v = v.As(label)
+
+	// THEN
+	assert.NotNil(t, v)
+	assert.Equal(t, fmt.Sprintf("%s.V().as(\"%s\")", graphName, label), v.String())
+}
+
+func TestVertexAsMulti(t *testing.T) {
+
+	// GIVEN
+	graphName := "mygraph"
+	g := NewGraph(graphName)
+	require.NotNil(t, g)
+	v := g.V()
+	require.NotNil(t, v)
+	l1 := "label1"
+	l2 := "label2"
+
+	// WHEN
+	v = v.As(l1, l2)
+
+	// THEN
+	assert.NotNil(t, v)
+	assert.Equal(t, fmt.Sprintf("%s.V().as(\"%s\",\"%s\")", graphName, l1, l2), v.String())
+}

--- a/cosmosResponse_test.go
+++ b/cosmosResponse_test.go
@@ -146,7 +146,7 @@ func TestParseAttributeMapFail(t *testing.T) {
 	}
 
 	// WHEN
-	responseInfo, err := parseAttributeMap(attributeMap)
+	_, err := parseAttributeMap(attributeMap)
 
 	// THEN
 	require.Error(t, err)
@@ -163,7 +163,7 @@ func TestParseAttributeMapFail(t *testing.T) {
 	}
 
 	// WHEN
-	responseInfo, err = parseAttributeMap(attributeMap)
+	responseInfo, err := parseAttributeMap(attributeMap)
 
 	// THEN
 	require.NoError(t, err)

--- a/interfaces/queryBuilder.go
+++ b/interfaces/queryBuilder.go
@@ -88,6 +88,9 @@ type Vertex interface {
 
 	// Limit adds .limit(<num>), to the query. The query call will limit the results of the query to the given number.
 	Limit(maxElements int) Vertex
+
+	// As adds .as([<label_1>,<label_2>,..,<label_n>]), to the query to label that query step for later access.
+	As(labels ...string) Vertex
 }
 
 type Edge interface {
@@ -121,6 +124,9 @@ type Edge interface {
 
 	// Limit adds .limit(<num>), to the query. The query call will limit the results of the query to the given number.
 	Limit(maxElements int) Edge
+
+	// As adds .as([<label_1>,<label_2>,..,<label_n>]), to the query to label that query step for later access.
+	As(labels ...string) Edge
 }
 
 type Property interface {
@@ -135,6 +141,9 @@ type Property interface {
 
 	// Limit adds .limit(<num>), to the query. The query call will limit the results of the query to the given number.
 	Limit(maxElements int) Property
+
+	// As adds .as([<label_1>,<label_2>,..,<label_n>]), to the query to label that query step for later access.
+	As(labels ...string) Property
 }
 
 type Dropper interface {


### PR DESCRIPTION
Documentation of the according step: https://tinkerpop.apache.org/docs/current/reference/#as-step