### PR TITLE
Convert retryAfter Gauge to Histogram

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ build: sep ## Builds the library
 
 test: sep ## Runs all unittests and generates a coverage report.
 	@echo "--> Run the unit-tests and checks for race conditions."
-	@go test . ./api ./interfaces -timeout 30s -race -run "^Test.*[^IT]$$" -covermode=atomic
+	@go test . ./api ./interfaces ./metrics -timeout 30s -race -run "^Test.*[^IT]$$" -covermode=atomic
 
 
 test.integration: sep ## Runs all integration tests. As precondition a local gremlin-server has to run and listen on port 8182.
@@ -31,7 +31,7 @@ lint: ## Runs the linter to check for coding-style issues
 
 report.test: sep ## Runs all unittests and generates a coverage- and a test-report.
 	@echo "--> Run the unit-tests"	
-	@go test . ./api ./interfaces -timeout 30s -race -run "^Test.*[^IT]$$" -covermode=atomic -coverprofile=coverage.out -json | tee test-report.out
+	@go test . ./api ./interfaces ./metrics -timeout 30s -race -run "^Test.*[^IT]$$" -covermode=atomic -coverprofile=coverage.out -json | tee test-report.out
 
 report.lint: ## Runs the linter to check for coding-style issues and generates the report file used in the ci pipeline
 	@echo "--> Lint project + Reporting"

--- a/Metrics.md
+++ b/Metrics.md
@@ -3,7 +3,7 @@
 | Name                                                | Help                                                                                                                                     | Type             |
 | :-------------------------------------------------- | :--------------------------------------------------------------------------------------------------------------------------------------- | :--------------- |
 | gremcos_cosmos_statuscode_total                     | Counts the number of responses from cosmos separated by status code.                                                                     | Labelled Counter |
-| gremcos_cosmos_retry_after_ms                       | The time in milliseconds suggested by cosmos to wait before issuing the next query.                                                      | Gauge            |
+| gremcos_cosmos_retry_after_ms                       | The time in milliseconds suggested by cosmos to wait before issuing the next query.                                                      | Histogram            |
 | gremcos_cosmos_request_charge_per_query             | Cosmos DB reports a request charge accumulated for all responses of one query. This metric represents that value.                        | Gauge            |
 | gremcos_cosmos_request_charge_per_queryresponse_avg | Cosmos DB reports a request charge each of the responses of one query. This metric represents the average of these values for one query. | Gauge            |
 | gremcos_cosmos_request_charge_total                 | The accumulated request charge over all queries issued so far.                                                                           | Counter          |

--- a/cosmos.go
+++ b/cosmos.go
@@ -296,7 +296,7 @@ func (c *cosmosImpl) retryLoop(executeRequest retryFun) (responses []interfaces.
 		if retryInformation.retryAfter > 0 {
 			c.logger.Info().Msgf("retry %d of query after %v because of header status code %d", tryCount+1, retryInformation.retryAfter, retryInformation.responseStatusCode)
 
-			if waitDone := waitForRetry(retryInformation.retryAfter, timeoutReachedChan); waitDone == false {
+			if waitDone := waitForRetry(retryInformation.retryAfter, timeoutReachedChan); !waitDone {
 				break
 			}
 		}
@@ -503,5 +503,5 @@ func updateRequestMetrics(responses []interfaces.Response, metrics *Metrics) {
 	metrics.requestChargePerQueryResponseAvg.Set(requestChargePerQueryResponseAvg)
 	metrics.requestChargePerQuery.Set(float64(requestChargePerQueryTotal))
 	metrics.requestChargeTotal.Add(float64(requestChargePerQueryTotal))
-	metrics.retryAfterMS.Set(float64(retryAfter.Milliseconds()))
+	metrics.retryAfterMS.Observe(float64(retryAfter.Milliseconds()))
 }

--- a/examples/cosmos_dynamic_credentials/main.go
+++ b/examples/cosmos_dynamic_credentials/main.go
@@ -77,7 +77,7 @@ func main() {
 		gremcos.NumMaxActiveConnections(10),
 		gremcos.ConnectionIdleTimeout(time.Second*30),
 		gremcos.MetricsPrefix("myservice"),
-		gremcos.AutomaticRetries(3),
+		gremcos.AutomaticRetries(3,time.Second * 2),
 	)
 
 	if err != nil {

--- a/examples/cosmos_static_credentials/main.go
+++ b/examples/cosmos_static_credentials/main.go
@@ -39,7 +39,7 @@ func main() {
 		gremcos.NumMaxActiveConnections(10),
 		gremcos.ConnectionIdleTimeout(time.Second*30),
 		gremcos.MetricsPrefix("myservice"),
-		gremcos.AutomaticRetries(3),
+		gremcos.AutomaticRetries(3,time.Second * 2),
 	)
 
 	if err != nil {

--- a/metrics.go
+++ b/metrics.go
@@ -11,7 +11,7 @@ import (
 // Metrics represents the collection of metrics internally set by the service.
 type Metrics struct {
 	statusCodeTotal                  m.CounterVec
-	retryAfterMS                     m.Gauge
+	retryAfterMS                     m.Histogram
 	requestChargeTotal               m.Counter
 	requestChargePerQuery            m.Gauge
 	requestChargePerQueryResponseAvg m.Gauge
@@ -35,11 +35,12 @@ func NewMetrics(namespace string) *Metrics {
 			Help:      "Counts the number of responses from cosmos separated by status code.",
 		}, statusCode)
 
-		retryAfterMS := promauto.NewGauge(prometheus.GaugeOpts{
+		retryAfterMS := promauto.NewHistogram(prometheus.HistogramOpts{
 			Namespace: namespace,
 			Subsystem: "cosmos",
 			Name:      "retry_after_ms",
 			Help:      "The time in milliseconds suggested by cosmos to wait before issuing the next query.",
+			Buckets: []float64{0,50,100,250,500,1000,5000,10000},
 		})
 
 		requestChargePerQuery := promauto.NewGauge(prometheus.GaugeOpts{
@@ -95,7 +96,7 @@ func newStubbedMetrics() *Metrics {
 	requestChargePerQuery := m.NewStubGauge()
 	requestChargeTotal := m.NewStubCounter()
 	statusCodeTotal := m.NewStubCounterVec()
-	retryAfterMS := m.NewStubGauge()
+	retryAfterMS := m.NewStubHistogram()
 	serverTimePerQueryMS := m.NewStubGauge()
 	serverTimePerQueryResponseAvgMS := m.NewStubGauge()
 

--- a/metrics/stub_metrics.go
+++ b/metrics/stub_metrics.go
@@ -73,3 +73,35 @@ var nopCounter = NewStubCounter()
 func (m *StubCounterVec) WithLabelValues(lvs ...string) Counter {
 	return nopCounter
 }
+
+// StubHistogram is a stub of Histogram interface
+type StubHistogram struct {
+}
+
+// NewStubHistogram creates a new stub instance
+func NewStubHistogram() *StubHistogram {
+	stub := &StubHistogram{}
+	return stub
+}
+
+// Observe stubs base method
+func (m *StubHistogram) Observe(arg0 float64) {
+	// just a Stub
+}
+
+// StubHistogramVec is a stub of HistogramVec interface
+type StubHistogramVec struct {
+}
+
+// NewHistogramVec creates a new stub instance
+func NewHistogramVec() *StubHistogramVec {
+	stub := &StubHistogramVec{}
+	return stub
+}
+
+var nopHistogram = NewStubHistogram()
+
+// WithLabelValues stubs base method
+func (m *StubHistogramVec) WithLabelValues(lvs ...string) Histogram {
+	return nopHistogram
+}

--- a/metrics/stub_metrics_test.go
+++ b/metrics/stub_metrics_test.go
@@ -1,0 +1,45 @@
+package metrics
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestNewStubHistogram(t *testing.T) {
+	// GIVEN
+	// WHEN
+	histogram := NewStubHistogram()
+
+	// THEN
+	assert.Equal(t, histogram,nopHistogram)
+}
+
+func TestObserve(t *testing.T) {
+	// GIVEN
+	histogram := NewStubHistogram()
+
+	// WHEN
+	histogram.Observe(4.2)
+
+	// THEN nothing happens
+}
+
+func TestNewStubHistogramVec(t *testing.T) {
+
+	// WHEN
+	histogramVec := NewHistogramVec()
+
+	// THEN
+	assert.NotNil(t, histogramVec)
+}
+
+func TestWithLabelValues(t *testing.T) {
+	// GIVEN
+	histogramVec := NewHistogramVec()
+
+	// WHEN
+	histogram := histogramVec.WithLabelValues("test", "values")
+
+	// THEN
+	assert.Equal(t, histogram,nopHistogram)
+}

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -10,7 +10,7 @@ import (
 
 type MetricsMocks struct {
 	statusCodeTotal                  *mock_metrics.MockCounterVec
-	retryAfterMS                     *mock_metrics.MockGauge
+	retryAfterMS                     *mock_metrics.MockHistogram
 	requestChargeTotal               *mock_metrics.MockCounter
 	requestChargePerQuery            *mock_metrics.MockGauge
 	requestChargePerQueryResponseAvg *mock_metrics.MockGauge
@@ -28,7 +28,7 @@ type MetricsMocks struct {
 // use metrics...
 func NewMockedMetrics(mockCtrl *gomock.Controller) (*Metrics, *MetricsMocks) {
 	mStatusCodeTotal := mock_metrics.NewMockCounterVec(mockCtrl)
-	mRetryAfterMS := mock_metrics.NewMockGauge(mockCtrl)
+	mRetryAfterMS := mock_metrics.NewMockHistogram(mockCtrl)
 	mRequestChargeTotal := mock_metrics.NewMockCounter(mockCtrl)
 	mRequestChargePerQuery := mock_metrics.NewMockGauge(mockCtrl)
 	mRequestChargePerQueryResponseAvg := mock_metrics.NewMockGauge(mockCtrl)
@@ -68,3 +68,5 @@ func Test_NewMetrics(t *testing.T) {
 	assert.NotNil(t, metrics.serverTimePerQueryMS)
 	assert.NotNil(t, metrics.serverTimePerQueryResponseAvgMS)
 }
+
+


### PR DESCRIPTION
The metric that captures the retryAfter values that cosmos returns is currently implemented as a gauge. But because receiving retryAfter is a sparse event the values will be invisible most of the time. A Histogram/Heatmap should fix this.
