### PR TITLE
enable eq, neq, gt, gte, lt, lte to handle different types of parameters

### DIFF
--- a/api/anonymous.go
+++ b/api/anonymous.go
@@ -3,6 +3,7 @@ package api
 import (
 	"github.com/pkg/errors"
 	"github.com/supplyon/gremcos/interfaces"
+	"reflect"
 )
 
 // WithinInt adds .within([<value_1>,<value_1>,..,<value_n>]), to the query. Where values are of type int.
@@ -15,34 +16,52 @@ func Within(values ...string) interfaces.QueryBuilder {
 	return multiParamQuery("within", values...)
 }
 
-// Eq adds .eq(<int>) to the query. (equal)
-func Eq(v int) interfaces.QueryBuilder {
-	return NewSimpleQB("eq(%d)", v)
+// Eq adds .eq(<T>) to the query. (equal)
+func Eq[T any](v T) interfaces.QueryBuilder {
+	if t := reflect.TypeOf(v).String(); t == "string" {
+		return NewSimpleQB("eq(\"%v\")", v)
+	}
+	return NewSimpleQB("eq(%v)", v)
 }
 
-// Neq adds .neq(<int>) to the query. (not equal)
-func Neq(v int) interfaces.QueryBuilder {
-	return NewSimpleQB("neq(%d)", v)
+// Neq adds .neq(<T>) to the query. (not equal)
+func Neq[T Ordered](v T) interfaces.QueryBuilder {
+	if t := reflect.TypeOf(v).String(); t == "string" {
+		return NewSimpleQB("neq(\"%v\")", v)
+	}
+	return NewSimpleQB("neq(%v)", v)
 }
 
-// Lt adds .lt(<int>) to the query. (less than)
-func Lt(v int) interfaces.QueryBuilder {
-	return NewSimpleQB("lt(%d)", v)
+// Lt adds .lt(<T>) to the query. (less than)
+func Lt[T Ordered](v T) interfaces.QueryBuilder {
+	if t := reflect.TypeOf(v).String(); t == "string" {
+		return NewSimpleQB("lt(\"%v\")", v)
+	}
+	return NewSimpleQB("lt(%v)", v)
 }
 
-// Lte adds .lte(<int>) to the query. (less than equal)
-func Lte(v int) interfaces.QueryBuilder {
-	return NewSimpleQB("lte(%d)", v)
+// Lte adds .lte(<T>) to the query. (less than equal)
+func Lte[T Ordered](v T) interfaces.QueryBuilder {
+	if t := reflect.TypeOf(v).String(); t == "string" {
+		return NewSimpleQB("lte(\"%v\")", v)
+	}
+	return NewSimpleQB("lte(%v)", v)
 }
 
-// Gt adds .gt(<int>) to the query. (greater than)
-func Gt(v int) interfaces.QueryBuilder {
-	return NewSimpleQB("gt(%d)", v)
+// Gt adds .gt(<T>) to the query. (greater than)
+func Gt[T Ordered](v T) interfaces.QueryBuilder {
+	if t := reflect.TypeOf(v).String(); t == "string" {
+		return NewSimpleQB("gt(\"%v\")", v)
+	}
+	return NewSimpleQB("gt(%v)", v)
 }
 
-// Gte adds .gte(<int>) to the query. (greater than equal)
-func Gte(v int) interfaces.QueryBuilder {
-	return NewSimpleQB("gte(%d)", v)
+// Gte adds .gte(<T>) to the query. (greater than equal)
+func Gte[T Ordered](v T) interfaces.QueryBuilder {
+	if t := reflect.TypeOf(v).String(); t == "string" {
+		return NewSimpleQB("gte(\"%v\")", v)
+	}
+	return NewSimpleQB("gte(%v)", v)
 }
 
 // InE adds .inE([<label_1>,<label_2>,..,<label_n>]), to the query. The query call returns all incoming edges of the Vertex
@@ -102,6 +121,7 @@ func Constant(c string) interfaces.QueryBuilder {
 // e.g. .has("temperature",23.02) or .has("available",true)
 // The method can also be used to return vertices that have a certain property.
 // Then .has("<prop name>") will be added to the query.
+//
 //	v.Has("prop1")
 func Has(key string, value ...interface{}) interfaces.QueryBuilder {
 	if len(value) == 0 {

--- a/api/anonymous_test.go
+++ b/api/anonymous_test.go
@@ -45,69 +45,87 @@ func TestAnonymousWithinInt(t *testing.T) {
 }
 
 func TestAnonymousEq(t *testing.T) {
-	// GIVEN
+	intInput := Eq(123)
+	assert.NotNil(t, intInput)
+	assert.Equal(t, "eq(123)", intInput.String())
 
-	// WHEN
-	e := Eq(123)
+	floatInput := Eq(-0.6)
+	assert.NotNil(t, floatInput)
+	assert.Equal(t, "eq(-0.6)", floatInput.String())
 
-	// THEN
-	assert.NotNil(t, e)
-	assert.Equal(t, "eq(123)", e.String())
+	stringInput := Eq("abc")
+	assert.NotNil(t, stringInput)
+	assert.Equal(t, `eq("abc")`, stringInput.String())
 }
 
 func TestAnonymousNeq(t *testing.T) {
-	// GIVEN
+	intInput := Neq(123)
+	assert.NotNil(t, intInput)
+	assert.Equal(t, "neq(123)", intInput.String())
 
-	// WHEN
-	e := Neq(123)
+	floatInput := Neq(-0.6)
+	assert.NotNil(t, floatInput)
+	assert.Equal(t, "neq(-0.6)", floatInput.String())
 
-	// THEN
-	assert.NotNil(t, e)
-	assert.Equal(t, "neq(123)", e.String())
+	stringInput := Neq("abc")
+	assert.NotNil(t, stringInput)
+	assert.Equal(t, `neq("abc")`, stringInput.String())
 }
 
 func TestAnonymousLt(t *testing.T) {
-	// GIVEN
+	intInput := Lt(123)
+	assert.NotNil(t, intInput)
+	assert.Equal(t, "lt(123)", intInput.String())
 
-	// WHEN
-	e := Lt(123)
+	floatInput := Lt(-0.6)
+	assert.NotNil(t, floatInput)
+	assert.Equal(t, "lt(-0.6)", floatInput.String())
 
-	// THEN
-	assert.NotNil(t, e)
-	assert.Equal(t, "lt(123)", e.String())
+	stringInput := Lt("abc")
+	assert.NotNil(t, stringInput)
+	assert.Equal(t, `lt("abc")`, stringInput.String())
 }
 
 func TestAnonymousLte(t *testing.T) {
-	// GIVEN
+	intInput := Lte(123)
+	assert.NotNil(t, intInput)
+	assert.Equal(t, "lte(123)", intInput.String())
 
-	// WHEN
-	e := Lte(123)
+	floatInput := Lte(-0.6)
+	assert.NotNil(t, floatInput)
+	assert.Equal(t, "lte(-0.6)", floatInput.String())
 
-	// THEN
-	assert.NotNil(t, e)
-	assert.Equal(t, "lte(123)", e.String())
+	stringInput := Lte("abc")
+	assert.NotNil(t, stringInput)
+	assert.Equal(t, `lte("abc")`, stringInput.String())
 }
 
 func TestAnonymousGt(t *testing.T) {
-	// GIVEN
+	intInput := Gt(123)
+	assert.NotNil(t, intInput)
+	assert.Equal(t, "gt(123)", intInput.String())
 
-	// WHEN
-	e := Gt(123)
+	floatInput := Gt(-0.6)
+	assert.NotNil(t, floatInput)
+	assert.Equal(t, "gt(-0.6)", floatInput.String())
 
-	// THEN
-	assert.NotNil(t, e)
-	assert.Equal(t, "gt(123)", e.String())
+	stringInput := Gt("abc")
+	assert.NotNil(t, stringInput)
+	assert.Equal(t, `gt("abc")`, stringInput.String())
 }
 
 func TestAnonymousGte(t *testing.T) {
-	// GIVEN
+	intInput := Gte(123)
+	assert.NotNil(t, intInput)
+	assert.Equal(t, "gte(123)", intInput.String())
 
-	// WHEN
-	e := Gte(123)
+	floatInput := Gte(-0.6)
+	assert.NotNil(t, floatInput)
+	assert.Equal(t, "gte(-0.6)", floatInput.String())
 
-	// THEN
-	assert.NotNil(t, e)
-	assert.Equal(t, "gte(123)", e.String())
+	stringInput := Gte("abc")
+	assert.NotNil(t, stringInput)
+	assert.Equal(t, `gte("abc")`, stringInput.String())
 }
 
 func TestAnonymousInE(t *testing.T) {

--- a/api/types.go
+++ b/api/types.go
@@ -6,6 +6,12 @@ import (
 	"github.com/spf13/cast"
 )
 
+// Ordered is a constraint that permits any ordered type: any type
+// that supports the operators < <= >= >.
+type Ordered interface {
+	~int | ~int8 | ~int16 | ~int32 | ~int64 | ~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64 | ~uintptr | ~float32 | ~float64 | ~string
+}
+
 // Property represents the cosmos db type for a property.
 // As it would be returned by a call to .properties().
 type Property struct {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/supplyon/gremcos
 
-go 1.13
+go 1.18
 
 require (
 	github.com/gofrs/uuid v3.2.0+incompatible
@@ -14,4 +14,19 @@ require (
 	github.com/stretchr/testify v1.7.0
 	go.uber.org/atomic v1.9.0
 	go.uber.org/goleak v1.1.12
+)
+
+require (
+	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/cespare/xxhash/v2 v2.1.2 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/prometheus/client_model v0.2.0 // indirect
+	github.com/prometheus/common v0.32.1 // indirect
+	github.com/prometheus/procfs v0.7.3 // indirect
+	golang.org/x/sys v0.0.0-20220114195835-da31bd327af9 // indirect
+	google.golang.org/protobuf v1.26.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -256,7 +256,6 @@ golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzB
 golang.org/x/mod v0.1.1-0.20191107180719-034126e5016b/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
-golang.org/x/mod v0.4.2 h1:Gz96sIWK3OalVv/I/qNygP42zyoKp3xptRVCWRFEBvo=
 golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=


### PR DESCRIPTION
- upgrade to Go 1.18 to use genereics
- introduce Ordered type similar to https://pkg.go.dev/golang.org/x/exp/constraints#Ordered
- have eq, neq, gt, gte, lt and lte accept Ordered types as parameter
- have these function return strings in quotes for cosmos compatibility
- add tests additionally for string and negative float